### PR TITLE
register wrapper after component mounted

### DIFF
--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -35,7 +35,7 @@ export default {
       return Object.keys(this.dialogs)
     }
   },
-  created () {
+  mounted () {
     if (process.env.NODE_ENV === 'development') {
       if (wrappers[this.name]) {
         console.error(`[vue-modal-dialogs] The wrapper '${this.name}' is already exist. Please make sure that every wrapper has a unique name.`)


### PR DESCRIPTION
I have multiple layouts, each containing a dialog-wrapper with the same name for the popup sidebar. This is necessary because the components do not know which layout they are currently using.

When I move from one layout to another, the plugin breaks down, because first a new version of the dialog-wrapper is registered and only then the old one is deleted, although it has already been overwritten.

I suggest registering the dialog-wrapper after mounting, which allows you to use wrappers with the same names in different parts of the application.

PS I'm not completely sure that such an edit does not break anything, but at least the tests do not fail, and everything worked in my project.