### PR TITLE
Fix import of vue-modal-dialogs in message-box example

### DIFF
--- a/src/examples/message-box/main.js
+++ b/src/examples/message-box/main.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import App from './App'
-import ModalDialogs from 'vue-modal-dialogs'
+import * as ModalDialogs from 'vue-modal-dialogs'
 
 // Install vue-modal-dialogs
 Vue.use(ModalDialogs)


### PR DESCRIPTION
There is no default export, so:

```js
import ModalDialogs from 'vue-modal-dialogs'
```

does not work, but the following does:

```js
import * as ModalDialogs from 'vue-modal-dialogs'
```

This is how it is currently in the Installation section of the README.